### PR TITLE
Sort permission call to work around /permissions API bug

### DIFF
--- a/download.py
+++ b/download.py
@@ -53,7 +53,7 @@ def getWorkspaceName(access_token, workspaceId):
 def getWorkspacePermissions(access_token, page = 1, size = 40):
   workspace_id = getWorkspaceId(getAccessTokenJson(access_token))
   url = mtm_base_url + "/workspaces/" + workspace_id + "/permissions"
-  params = { 'page': page, 'size': size, 'status': '!ARCHIVED' }
+  params = { 'page': page, 'size': size, 'status': '!ARCHIVED', 'sort': 'lastLogin-asc' }
   headers = { 'Authorization': 'Bearer ' + access_token, 'Content-Type': 'application/json' }
   print('Fetching permissions page 1...')
   response = callGet(url, headers, params)


### PR DESCRIPTION
For large workspaces (4000+ users in our case), we have issues with the paged queries to the /permissions API: Some users are returned as duplicates, while others are dropped entirey. Adding a sort parameter works around this issue (but I would of course appreciate if the problem was rather fixed internally). Thanks!